### PR TITLE
ls() and lsf() return symbols rather than full variables/factors

### DIFF
--- a/src/CloudGraphsDFG/services/CloudGraphsDFG.jl
+++ b/src/CloudGraphsDFG/services/CloudGraphsDFG.jl
@@ -541,25 +541,15 @@ Delete the referened DFGFactor from the DFG.
 """
 deleteFactor!(dfg::CloudGraphsDFG, factor::DFGFactor)::DFGFactor = deleteFactor!(dfg, factor.label)
 
-# Returns a flat vector of the vertices, keyed by ID.
-# Assuming only variables here for now - think maybe not, should be variables+factors?
 """
     $(SIGNATURES)
 List the DFGVariables in the DFG.
 Optionally specify a label regular expression to retrieves a subset of the variables.
 """
-function ls(dfg::CloudGraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{DFGVariable}
+function getVariables(dfg::CloudGraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{DFGVariable}
     variableIds = getVariableIds(dfg, regexFilter)
     return map(vId->getVariable(dfg, vId), variableIds)
 end
-
-# Alias
-"""
-    $(SIGNATURES)
-List the DFGVariables in the DFG.
-Optionally specify a label regular expression to retrieves a subset of the variables.
-"""
-getVariables(dfg::CloudGraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{DFGVariable} = ls(dfg, regexFilter)
 
 """
     $(SIGNATURES)
@@ -575,32 +565,22 @@ function getVariableIds(dfg::CloudGraphsDFG, regexFilter::Union{Nothing, Regex}=
     end
 end
 
-"""
-    $(SIGNATURES)
-List the DFGFactors in the DFG.
-Optionally specify a label regular expression to retrieves a subset of the factors.
-"""
-function lsf(dfg::CloudGraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{DFGFactor}
-    factorIds = getFactorIds(dfg, regexFilter)
-    return map(vId->getFactor(dfg, vId), factorIds)
-end
-
 # Alias
 """
     $(SIGNATURES)
+List the DFGVariables in the DFG.
+Optionally specify a label regular expression to retrieves a subset of the variables.
+"""
+ls(dfg::CloudGraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{Symbol} = getVariableIds(dfg, regexFilter)
+
+"""
+    $(SIGNATURES)
 List the DFGFactors in the DFG.
 Optionally specify a label regular expression to retrieves a subset of the factors.
 """
-getFactors(dfg::CloudGraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{DFGFactor} = lsf(dfg, regexFilter)
-
-# Alias - getNeighbors
-#TODO: Refactor this
-"""
-    $(SIGNATURES)
-Get neighbors around a given node. TODO: Refactor this
-"""
-function lsf(dfg::CloudGraphsDFG, label::Symbol)::Vector{Symbol}
-  return getNeighbors(dfg, label)
+function getFactors(dfg::CloudGraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{DFGFactor}
+    factorIds = getFactorIds(dfg, regexFilter)
+    return map(vId->getFactor(dfg, vId), factorIds)
 end
 
 """
@@ -615,6 +595,23 @@ function getFactorIds(dfg::CloudGraphsDFG, regexFilter::Union{Nothing, Regex}=no
     else
         return _getLabelsFromCyphonQuery(dfg.neo4jInstance, "(node:$(dfg.userId):$(dfg.robotId):$(dfg.sessionId):FACTOR) where node.label =~ '$(regexFilter.pattern)'")
     end
+end
+
+# Alias
+"""
+    $(SIGNATURES)
+List the DFGFactors in the DFG.
+Optionally specify a label regular expression to retrieves a subset of the factors.
+"""
+lsf(dfg::CloudGraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{Symbol} = getFactorIds(dfg, regexFilter)
+
+# Alias - getNeighbors
+"""
+    $(SIGNATURES)
+Get neighbors around a given node. TODO: Refactor this
+"""
+function lsf(dfg::CloudGraphsDFG, label::Symbol)::Vector{Symbol}
+  return getNeighbors(dfg, label)
 end
 
 """

--- a/src/CloudGraphsDFG/services/CloudGraphsDFG.jl
+++ b/src/CloudGraphsDFG/services/CloudGraphsDFG.jl
@@ -12,7 +12,7 @@ function _getname(t::T) where T
   T.name.name
 end
 
-# Simply for convenience -don't export
+# Simply for convenience - don't export
 const PackedFunctionNodeData{T} = GenericFunctionNodeData{T, <: AbstractString}
 PackedFunctionNodeData(x1, x2, x3, x4, x5::S, x6::T, x7::String="", x8::Vector{Int}=Int[]) where {T <: PackedInferenceType, S <: AbstractString} = GenericFunctionNodeData(x1, x2, x3, x4, x5, x6, x7, x8)
 const FunctionNodeData{T} = GenericFunctionNodeData{T, Symbol}

--- a/src/GraphsDFG/services/GraphsDFG.jl
+++ b/src/GraphsDFG/services/GraphsDFG.jl
@@ -209,14 +209,12 @@ Delete the referened DFGFactor from the DFG.
 """
 deleteFactor!(dfg::GraphsDFG, factor::DFGFactor)::DFGFactor = deleteFactor!(dfg, factor.label)
 
-# # Returns a flat vector of the vertices, keyed by ID.
-# # Assuming only variables here for now - think maybe not, should be variables+factors?
 """
     $(SIGNATURES)
 List the DFGVariables in the DFG.
 Optionally specify a label regular expression to retrieves a subset of the variables.
 """
-function ls(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing; tags::Vector{Symbol}=Symbol[])::Vector{DFGVariable}
+function getVariables(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing; tags::Vector{Symbol}=Symbol[])::Vector{DFGVariable}
     variables = map(v -> v.dfgNode, filter(n -> n.dfgNode isa DFGVariable, vertices(dfg.g)))
     if regexFilter != nothing
         variables = filter(v -> occursin(regexFilter, String(v.label)), variables)
@@ -227,14 +225,6 @@ function ls(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing; tags::Ve
     end
 	return variables
 end
-
-# Alias
-"""
-    $(SIGNATURES)
-List the DFGVariables in the DFG.
-Optionally specify a label regular expression to retrieves a subset of the variables.
-"""
-getVariables(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing; tags::Vector{Symbol}=Symbol[])::Vector{DFGVariable} = ls(dfg, regexFilter, tags=tags)
 
 """
     $(SIGNATURES)
@@ -251,42 +241,54 @@ Related
 ls
 """
 function getVariableIds(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing; tags::Vector{Symbol}=Symbol[])::Vector{Symbol}
-  vars = ls(dfg, regexFilter, tags=tags)
+  vars = getVariables(dfg, regexFilter, tags=tags)
   # mask = map(v -> length(intersect(v.tags, tags)) > 0, vars )
   map(v -> v.label, vars)
-end
-
-
-"""
-    $(SIGNATURES)
-List the DFGFactors in the DFG.
-Optionally specify a label regular expression to retrieves a subset of the factors.
-"""
-function lsf(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{DFGFactor}
-    factors = map(v -> v.dfgNode, filter(n -> n.dfgNode isa DFGFactor, vertices(dfg.g)))
-    if regexFilter != nothing
-        factors = filter(f -> occursin(regexFilter, String(f.label)), factors)
-    end
-    return factors
-end
-function lsf(dfg::GraphsDFG, label::Symbol)::Vector{Symbol}
-  return getNeighbors(dfg, label)
 end
 
 # Alias
 """
     $(SIGNATURES)
+List the DFGVariables in the DFG.
+Optionally specify a label regular expression to retrieves a subset of the variables.
+"""
+ls(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing; tags::Vector{Symbol}=Symbol[])::Vector{Symbol} = getVariableIds(dfg, regexFilter, tags=tags)
+
+"""
+    $(SIGNATURES)
 List the DFGFactors in the DFG.
 Optionally specify a label regular expression to retrieves a subset of the factors.
 """
-getFactors(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{DFGFactor} = lsf(dfg, regexFilter)
+function getFactors(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{DFGFactor}
+	factors = map(v -> v.dfgNode, filter(n -> n.dfgNode isa DFGFactor, vertices(dfg.g)))
+	if regexFilter != nothing
+		factors = filter(f -> occursin(regexFilter, String(f.label)), factors)
+	end
+	return factors
+end
 
 """
     $(SIGNATURES)
 Get a list of the IDs of the DFGFactors in the DFG.
 Optionally specify a label regular expression to retrieves a subset of the factors.
 """
-getFactorIds(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{Symbol} = map(f -> f.label, lsf(dfg, regexFilter))
+getFactorIds(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{Symbol} = map(f -> f.label, getFactors(dfg, regexFilter))
+
+"""
+    $(SIGNATURES)
+List the DFGFactors in the DFG.
+Optionally specify a label regular expression to retrieves a subset of the factors.
+"""
+# Alias
+lsf(dfg::GraphsDFG, regexFilter::Union{Nothing, Regex}=nothing)::Vector{Symbol} = getFactorIds(dfg, regexFilter)
+
+"""
+	$(SIGNATURES)
+Alias for getNeighbors - returns neighbors around a given node label.
+"""
+function lsf(dfg::GraphsDFG, label::Symbol)::Vector{Symbol}
+  return getNeighbors(dfg, label)
+end
 
 """
     $(SIGNATURES)

--- a/test/cloudGraphsDFGTests.jl
+++ b/test/cloudGraphsDFGTests.jl
@@ -6,6 +6,7 @@
 # Run: sudo docker run --publish=7474:7474 --publish=7687:7687 --env NEO4J_AUTH=neo4j/test neo4j
 
 using Revise
+using Neo4j
 using DistributedFactorGraphs
 using IncrementalInference
 using Test
@@ -15,7 +16,7 @@ using RoME
 @testset "Setup and clearing the existing graph" begin
     # Create connection
     # Caching: Off
-    global cgDFG = CloudGraphsDFG("localhost", 7474, "neo4j", "test",
+    global cgDFG = CloudGraphsDFG{NoSolverParams}("localhost", 7474, "neo4j", "test",
         "testUser", "testRobot", "testSession",
         nothing,
         nothing,
@@ -92,12 +93,12 @@ end
     # Not fast though, TODO: https://github.com/JuliaRobotics/DistributedFactorGraphs.jl/issues/39
     vars = getVariables(cgDFG)
     vars2 = ls(cgDFG)
-    @test map(v->v.label, vars) == map(v->v.label, vars2)
+    @test map(v->v.label, vars) == vars2
     @test symdiff(map(v->v.label, vars), [:x1, :x2, :x3, :l1, :l2]) == []
 
     facts = getFactors(cgDFG)
     facts2 = lsf(cgDFG)
-    @test map(v->v.label, facts) == map(v->v.label, facts2)
+    @test map(v->v.label, facts) == facts2
     @test symdiff(map(f->f.label, facts), [:x1x2f1, :x1f1, :x2l1f1, :x2x3f1, :x3l2f1, :x1l1f1]) == []
 
     @test symdiff(getNeighbors(cgDFG, :x2), [:x2l1f1, :x2x3f1, :x1x2f1]) == []
@@ -167,13 +168,6 @@ end
     # Final cleanup
     # clearSession!!(cgDFGCopy)
 end
-
-global cgDFG = CloudGraphsDFG("localhost", 7474, "neo4j", "test",
-    "testUser", "testRobot", "testSession",
-    nothing,
-    nothing,
-    IncrementalInference.decodePackedType)
-
 
 @testset "getAdjacencyMatrix test" begin
     adjMat = getAdjacencyMatrix(cgDFG)

--- a/test/interfaceTests.jl
+++ b/test/interfaceTests.jl
@@ -17,8 +17,8 @@ addFactor!(dfg, [v1, v2], f1)
     @test symdiff([:a, :b], getVariableIds(dfg)) == []
     @test getFactorIds(dfg) == [:f1]
     # Regexes
-    @test ls(dfg, r"a") == [v1]
-    @test lsf(dfg, r"f*") == [f1]
+    @test ls(dfg, r"a") == [v1.label]
+    @test lsf(dfg, r"f*") == [f1.label]
     # Accessors
     @test getAddHistory(dfg) == [:a, :b] #, :f1
     @test getDescription(dfg) != nothing
@@ -118,13 +118,13 @@ end
     # Subgraphs
     dfgSubgraph = getSubgraphAroundNode(dfg, verts[1], 2)
     # Only returns x1 and x2
-    @test symdiff([:x1, :x1x2f1, :x2], map(n -> n.label, [ls(dfgSubgraph)..., lsf(dfgSubgraph)...])) == []
+    @test symdiff([:x1, :x1x2f1, :x2], [ls(dfgSubgraph)..., lsf(dfgSubgraph)...]) == []
     # Test include orphan factorsVoid
     dfgSubgraph = getSubgraphAroundNode(dfg, verts[1], 1, true)
-    @test symdiff([:x1, :x1x2f1], map(n -> n.label, [ls(dfgSubgraph)..., lsf(dfgSubgraph)...])) == []
+    @test symdiff([:x1, :x1x2f1], [ls(dfgSubgraph)..., lsf(dfgSubgraph)...]) == []
     # Test adding to the dfg
     dfgSubgraph = getSubgraphAroundNode(dfg, verts[1], 2, true, dfgSubgraph)
-    @test symdiff([:x1, :x1x2f1, :x2], map(n -> n.label, [ls(dfgSubgraph)..., lsf(dfgSubgraph)...])) == []
+    @test symdiff([:x1, :x1x2f1, :x2], [ls(dfgSubgraph)..., lsf(dfgSubgraph)...]) == []
 end
 
 @testset "Producing Dot Files" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using DistributedFactorGraphs
 apis = [GraphsDFG]
 # apis = [graphsDFG, cgDFG]
 for api in apis
-    @testset "Testing Driver: $(typeof(api))" begin
+    @testset "Testing Driver: $(api)" begin
         global testDFGAPI = api
         include("interfaceTests.jl")
     end


### PR DESCRIPTION
This addresses the difference in the new API vs. the prior IncrementalInference API. The two should match now.

Issues addressed:
* #40 