### PR TITLE
Sparse Int Adjacency matrix

### DIFF
--- a/src/LightGraphsDFG/LightGraphsDFG.jl
+++ b/src/LightGraphsDFG/LightGraphsDFG.jl
@@ -16,7 +16,7 @@ export ls, lsf, getVariables, getFactors, getVariableIds, getFactorIds
 export getVariable, getFactor
 export updateVariable!, updateFactor!
 export deleteVariable!, deleteFactor!
-export getAdjacencyMatrix
+export getAdjacencyMatrix, getAdjacencyMatrixSparse
 export getAdjacencyMatrixDataFrame
 export getNeighbors
 export getSubgraphAroundNode

--- a/src/LightGraphsDFG/services/LightGraphsDFG.jl
+++ b/src/LightGraphsDFG/services/LightGraphsDFG.jl
@@ -525,6 +525,10 @@ function getAdjacencyMatrix(dfg::LightGraphsDFG)::Matrix{Union{Nothing, Symbol}}
     return adjMat
 end
 
+function exp_getAdjacencyMatrix(dfg::LightGraphsDFG)
+    adj = LightGraphs.adjacency_matrix(dfg.g)
+	return adj, dfg.g.metaindex[:label]
+end
 
 """
     $(SIGNATURES)

--- a/src/LightGraphsDFG/services/LightGraphsDFG.jl
+++ b/src/LightGraphsDFG/services/LightGraphsDFG.jl
@@ -527,7 +527,12 @@ end
 
 function exp_getAdjacencyMatrix(dfg::LightGraphsDFG)
     adj = LightGraphs.adjacency_matrix(dfg.g)
-	return adj, dfg.g.metaindex[:label]
+	v_labels = getVariableIds(dfg)
+	f_labels = getFactorIds(dfg)
+	v_index = [dfg.g[s,:label] for s in v_labels]
+	f_index = [dfg.g[s,:label] for s in f_labels]
+	adjvf = adj[f_index, v_index]
+	return adjvf, v_labels, f_labels
 end
 
 """

--- a/src/LightGraphsDFG/services/LightGraphsDFG.jl
+++ b/src/LightGraphsDFG/services/LightGraphsDFG.jl
@@ -525,7 +525,7 @@ function getAdjacencyMatrix(dfg::LightGraphsDFG)::Matrix{Union{Nothing, Symbol}}
     return adjMat
 end
 
-function exp_getAdjacencyMatrix(dfg::LightGraphsDFG)
+function getAdjacencyMatrixSparse(dfg::LightGraphsDFG)
     adj = LightGraphs.adjacency_matrix(dfg.g)
 	v_labels = getVariableIds(dfg)
 	f_labels = getFactorIds(dfg)


### PR DESCRIPTION
PR For discussion @GearsAD @dehann

Currently Dense `Union{Nothing, Symbol}`
```
@time getAdjacencyMatrix(dfg)
  0.000129 seconds (757 allocations: 87.281 KiB)
```

Working with spare matrix as Adjacency Matrix
 ```
@time exp_getAdjacencyMatrix(dfg)
  0.000013 seconds (11 allocations: 1.531 KiB)
```
```julia
23×23 SparseArrays.SparseMatrixCSC{Int64,Int64} with 48 stored entries:
  [11,  1]  =  1
  [11,  2]  =  1
  ⋮
  [9 , 23]  =  1
  [20, 23]  =  1
```
Navigation type factor graphs adjacency will mostly be very sparse 
1. Should sparse matrices (or maybe adjacency lists if symbols are used) be used throughout DFG getAdjacencyMatrix
2. How do we want to handle labels. 
     - Sparse internal id (`Int`) sparse matrix with a map for the `Int`s <-> labels. 
     - Sparse label matrix
     - List of adjacent labels 
     - Fastest most efficient would be to use iterators and `Int` in IIF. Although, it would only make sense with in memory types. 
