### PR TITLE
Removing DataFrame references

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.4.0"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/docs/src/func_ref.md
+++ b/docs/src/func_ref.md
@@ -63,8 +63,3 @@ getSubgraph
 toDot
 toDotFile
 ```
-
-### DataFrame Extension Functions
-```@docs
-getAdjacencyMatrixDataFrame
-```

--- a/src/CloudGraphsDFG/CloudGraphsDFG.jl
+++ b/src/CloudGraphsDFG/CloudGraphsDFG.jl
@@ -20,7 +20,6 @@ export getVariable, getFactor
 export updateVariable!, updateFactor!
 export deleteVariable!, deleteFactor!
 export getAdjacencyMatrix
-export getAdjacencyMatrixDataFrame
 export getNeighbors
 export getSubgraphAroundNode
 export getSubgraph

--- a/src/CloudGraphsDFG/services/CloudGraphsDFG.jl
+++ b/src/CloudGraphsDFG/services/CloudGraphsDFG.jl
@@ -815,30 +815,3 @@ end
 #     end
 #     return nothing
 # end
-#
-# function __init__()
-#     @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
-#         if isdefined(Main, :DataFrames)
-#             """
-#                 $(SIGNATURES)
-#             Get an adjacency matrix for the DFG as a DataFrame.
-#             Rows are all factors, columns are all variables, and each cell contains either nothing or the symbol of the relating factor.
-#             The first column is the factor headings.
-#             """
-#             function getAdjacencyMatrixDataFrame(dfg::CloudGraphsDFG)::Main.DataFrames.DataFrame
-#                 varLabels = sort(map(v->v.label, getVariables(dfg)))
-#                 factLabels = sort(map(f->f.label, getFactors(dfg)))
-#                 adjDf = DataFrames.DataFrame(:Factor => Union{Missing, Symbol}[])
-#                 for varLabel in varLabels
-#                     adjDf[varLabel] = Union{Missing, Symbol}[]
-#                 end
-#                 for (i, factLabel) in enumerate(factLabels)
-#                     push!(adjDf, [factLabel, DataFrames.missings(length(varLabels))...])
-#                     factVars = getNeighbors(dfg, getFactor(dfg, factLabel))
-#                     map(vLabel -> adjDf[vLabel][i] = factLabel, factVars)
-#                 end
-#                 return adjDf
-#             end
-#         end
-#     end
-# end

--- a/src/DistributedFactorGraphs.jl
+++ b/src/DistributedFactorGraphs.jl
@@ -60,31 +60,6 @@ include("LightDFG/LightDFG.jl")
 export saveDFG, loadDFG
 
 function __init__()
-    @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
-        if isdefined(Main, :DataFrames)
-            """
-                $(SIGNATURES)
-            Get an adjacency matrix for the DFG as a DataFrame.
-            Rows are all factors, columns are all variables, and each cell contains either nothing or the symbol of the relating factor.
-            The first column is the factor headings.
-            """
-            function getAdjacencyMatrixDataFrame(dfg::Union{GraphsDFG, MetaGraphsDFG, SymbolDFG, LightDFG})::Main.DataFrames.DataFrame
-                varLabels = sort(map(v->v.label, getVariables(dfg)))
-                factLabels = sort(map(f->f.label, getFactors(dfg)))
-                adjDf = DataFrames.DataFrame(:Factor => Union{Missing, Symbol}[])
-                for varLabel in varLabels
-                    adjDf[varLabel] = Union{Missing, Symbol}[]
-                end
-                for (i, factLabel) in enumerate(factLabels)
-                    push!(adjDf, [factLabel, DataFrames.missings(length(varLabels))...])
-                    factVars = getNeighbors(dfg, getFactor(dfg, factLabel))
-                    map(vLabel -> adjDf[vLabel][i] = factLabel, factVars)
-                end
-                return adjDf
-            end
-        end
-    end
-
     @require Neo4j="d2adbeaf-5838-5367-8a2f-e46d570981db" begin
         # Include the Cloudgraphs API
         include("CloudGraphsDFG/CloudGraphsDFG.jl")

--- a/src/GraphsDFG/GraphsDFG.jl
+++ b/src/GraphsDFG/GraphsDFG.jl
@@ -16,7 +16,6 @@ export getVariable, getFactor
 export updateVariable!, updateFactor!
 export deleteVariable!, deleteFactor!
 export getAdjacencyMatrix
-export getAdjacencyMatrixDataFrame
 export getNeighbors
 export getSubgraphAroundNode
 export getSubgraph

--- a/src/GraphsDFG/services/GraphsDFG.jl
+++ b/src/GraphsDFG/services/GraphsDFG.jl
@@ -527,30 +527,3 @@ function toDotFile(dfg::GraphsDFG, fileName::String="/tmp/dfg.dot")::Nothing
     end
     return nothing
 end
-
-# function __init__()
-#     @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
-#         if isdefined(Main, :DataFrames)
-#             """
-#                 $(SIGNATURES)
-#             Get an adjacency matrix for the DFG as a DataFrame.
-#             Rows are all factors, columns are all variables, and each cell contains either nothing or the symbol of the relating factor.
-#             The first column is the factor headings.
-#             """
-#             function getAdjacencyMatrixDataFrame(dfg::GraphsDFG)::Main.DataFrames.DataFrame
-#                 varLabels = sort(map(v->v.label, getVariables(dfg)))
-#                 factLabels = sort(map(f->f.label, getFactors(dfg)))
-#                 adjDf = DataFrames.DataFrame(:Factor => Union{Missing, Symbol}[])
-#                 for varLabel in varLabels
-#                     adjDf[varLabel] = Union{Missing, Symbol}[]
-#                 end
-#                 for (i, factLabel) in enumerate(factLabels)
-#                     push!(adjDf, [factLabel, DataFrames.missings(length(varLabels))...])
-#                     factVars = getNeighbors(dfg, getFactor(dfg, factLabel))
-#                     map(vLabel -> adjDf[vLabel][i] = factLabel, factVars)
-#                 end
-#                 return adjDf
-#             end
-#         end
-#     end
-# end

--- a/src/MetaGraphsDFG/MetaGraphsDFG.jl
+++ b/src/MetaGraphsDFG/MetaGraphsDFG.jl
@@ -17,7 +17,6 @@ export getVariable, getFactor
 export updateVariable!, updateFactor!
 export deleteVariable!, deleteFactor!
 export getAdjacencyMatrix, getAdjacencyMatrixSparse
-export getAdjacencyMatrixDataFrame
 export getNeighbors
 export getSubgraphAroundNode
 export getSubgraph

--- a/test/FileDFG.jl
+++ b/test/FileDFG.jl
@@ -1,4 +1,3 @@
-using Revise
 using Test
 using DistributedFactorGraphs
 using IncrementalInference, RoME

--- a/test/interfaceTests.jl
+++ b/test/interfaceTests.jl
@@ -4,7 +4,7 @@ v2 = DFGVariable(:b)
 f1 = DFGFactor{Int, :Symbol}(:f1)
 
 #add tags for filters
-append!(v1.tags,[:VARIABLE, :POSE])
+append!(v1.tags, [:VARIABLE, :POSE])
 append!(v2.tags, [:VARIABLE, :LANDMARK])
 append!(f1.tags, [:FACTOR])
 
@@ -121,10 +121,6 @@ end
     # @test adjMat[1, 3] == 1
     @test symdiff(v_ll, [:a, :b, :orphan]) == Symbol[]
     @test symdiff(f_ll, [:f1, :f1, :f1]) == Symbol[]
-
-    # Dataframe
-    adjDf = getAdjacencyMatrixDataFrame(dfg)
-    @test size(adjDf) == (1,4)
 end
 
 # Deletions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using Test
-using DataFrames
 using DistributedFactorGraphs
 
 # Test each interface
@@ -10,6 +9,11 @@ for api in apis
         include("interfaceTests.jl")
     end
 end
+
+# Test extensions
+# @testset "DFG Extensions" begin
+#     include("FileDFG.jl")
+# end
 
 # if !(get(ENV, "TRAVIS", "") == "true")
 #     @testset "Local Testsets" begin


### PR DESCRIPTION
The DataFrame adjacency matrix functionality isn't really used and it adds complexity so removing for 0.4 release.

Ref: #101 