### PR TITLE
Clearer depreciation error in Symbol and Light DFG

### DIFF
--- a/src/LightDFG/entities/LightDFG.jl
+++ b/src/LightDFG/entities/LightDFG.jl
@@ -34,10 +34,10 @@ Base.propertynames(x::LightDFG, private::Bool=false) =
 
 Base.getproperty(x::LightDFG,f::Symbol) = begin
     if f == :nodeCounter
-        @error "Depreciated? returning number of nodes"
+        @error "Field nodeCounter depreciated. returning number of nodes"
         nv(x.g)
     elseif f == :labelDict
-        @error "Depreciated? Consider using exists(dfg,label) instead. Returning internals copy"
+        @error "Field labelDict depreciated. Consider using exists(dfg,label) or getLabelDict(dfg) instead. Returning internals copy"
         #TODO: https://github.com/JuliaRobotics/DistributedFactorGraphs.jl/issues/111
         copy(x.g.labels.sym_int)
     else

--- a/src/LightDFG/services/LightDFG.jl
+++ b/src/LightDFG/services/LightDFG.jl
@@ -1,7 +1,7 @@
 
 
 # Accessors
-getLabelDict(dfg::LightDFG) = dfg.labelDict
+getLabelDict(dfg::LightDFG) = copy(dfg.g.labels.sym_int)
 getDescription(dfg::LightDFG) = dfg.description
 setDescription(dfg::LightDFG, description::String) = dfg.description = description
 getInnerGraph(dfg::LightDFG) = dfg.g

--- a/src/MetaGraphsDFG/entities/MetaGraphsDFG.jl
+++ b/src/MetaGraphsDFG/entities/MetaGraphsDFG.jl
@@ -45,10 +45,11 @@ Base.propertynames(x::MetaGraphsDFG, private::Bool=false) =
 
 Base.getproperty(x::MetaGraphsDFG,f::Symbol) = begin
     if f == :nodeCounter
+        @warn "Field nodeCounter depreciated. returning number of nodes"
         nv(x.g)
     elseif f == :labelDict
-        @warn "Read only! using internal labelDict"
-        x.g.metaindex[:label]
+        @warn "Field labelDict depreciated. Consider using exists(dfg,label) or getLabelDict(dfg) instead. Returning internals copy"
+        copy(x.g.metaindex[:label])
     else
         getfield(x,f)
     end

--- a/src/MetaGraphsDFG/services/MetaGraphsDFG.jl
+++ b/src/MetaGraphsDFG/services/MetaGraphsDFG.jl
@@ -1,5 +1,5 @@
 # Accessors
-getLabelDict(dfg::MetaGraphsDFG) = dfg.g.metaindex[:label]
+getLabelDict(dfg::MetaGraphsDFG) = copy(dfg.g.metaindex[:label])
 getDescription(dfg::MetaGraphsDFG) = dfg.description
 setDescription(dfg::MetaGraphsDFG, description::String) = dfg.description = description
 getInnerGraph(dfg::MetaGraphsDFG) = dfg.g

--- a/src/SymbolDFG/entities/SymbolDFG.jl
+++ b/src/SymbolDFG/entities/SymbolDFG.jl
@@ -32,11 +32,11 @@ Base.propertynames(x::SymbolDFG, private::Bool=false) =
 
 Base.getproperty(x::SymbolDFG,f::Symbol) = begin
     if f == :nodeCounter
-        @error "Depreciated? returning number of nodes"
+        @error "Field nodeCounter depreciated. returning number of nodes"
         nv(x.g)
     elseif f == :labelDict
-        @error "Maybe depreciated? using internals"
-        x.g.fadjdict
+        @error "Field labelDict depreciated. Consider using exists(dfg,label) or getLabelDict(dfg) instead. Returning internals copy"
+        copy(x.g.fadjdict)
     else
         getfield(x,f)
     end

--- a/src/SymbolDFG/services/SymbolDFG.jl
+++ b/src/SymbolDFG/services/SymbolDFG.jl
@@ -1,6 +1,6 @@
 
 # Accessors
-getLabelDict(dfg::SymbolDFG) = dfg.labelDict
+getLabelDict(dfg::SymbolDFG) = copy(dfg.g.fadjdict)
 getDescription(dfg::SymbolDFG) = dfg.description
 setDescription(dfg::SymbolDFG, description::String) = dfg.description = description
 getInnerGraph(dfg::SymbolDFG) = dfg.g

--- a/test/interfaceTests.jl
+++ b/test/interfaceTests.jl
@@ -17,7 +17,7 @@ addFactor!(dfg, [v1, v2], f1)
 # end
 
 @testset "Adding Removing Nodes" begin
-    dfg2 = GraphsDFG{NoSolverParams}()
+    dfg2 = testDFGAPI{NoSolverParams}()
     v1 = DFGVariable(:a)
     v2 = DFGVariable(:b)
     v3 = DFGVariable(:c)

--- a/test/interfaceTests.jl
+++ b/test/interfaceTests.jl
@@ -174,6 +174,12 @@ end
     @test getFactorIds(dfg) == []
     deleteVariable!(dfg, :b)
     @test symdiff([:a, :orphan], getVariableIds(dfg)) == []
+    #delete last also for the LightGraphs implementation coverage
+    deleteVariable!(dfg, :orphan)
+    @test symdiff([:a], getVariableIds(dfg)) == []
+    deleteVariable!(dfg, :a)
+    @test getVariableIds(dfg) == []
+
 end
 
 


### PR DESCRIPTION
Clearer depreciation error in Meta, Symbol, and Light DFG for direct field access on nodeCounter and labelDict
Hopefully clears #111 up a bit.
Fixes #121, if it should be fixed?
