### PR TITLE
remove LigthGraphs from DFG.jl to avoid conflicts in IIF

### DIFF
--- a/src/DistributedFactorGraphs.jl
+++ b/src/DistributedFactorGraphs.jl
@@ -9,8 +9,6 @@ using Reexport
 using JSON2
 using LinearAlgebra
 using SparseArrays
-# This is used in the definition of getAdjacencyMatrixSparse
-using LightGraphs
 
 # Entities
 include("entities/AbstractDFG.jl")

--- a/src/services/AbstractDFG.jl
+++ b/src/services/AbstractDFG.jl
@@ -498,7 +498,7 @@ end
 Get an adjacency matrix for the DFG, returned as a tuple: adjmat::SparseMatrixCSC{Int}, var_labels::Vector{Symbol) fac_labels::Vector{Symbol).
 Rows are the factors, columns are the variables, with the corresponding labels in fac_labels,var_labels.
 """
-function getAdjacencyMatrixSparse(dfg::G; solvable::Int=0)::Tuple{LightGraphs.SparseMatrixCSC, Vector{Symbol}, Vector{Symbol}} where G <: AbstractDFG
+function getAdjacencyMatrixSparse(dfg::G; solvable::Int=0)::Tuple{SparseMatrixCSC, Vector{Symbol}, Vector{Symbol}} where G <: AbstractDFG
 	varLabels = map(v->v.label, getVariables(dfg, solvable=solvable))
 	factLabels = map(f->f.label, getFactors(dfg, solvable=solvable))
 


### PR DESCRIPTION
WARNING: using LightGraphs.AbstractGraph in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.maximum_adjacency_visit in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.strongly_connected_components in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.connected_components in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.Edge in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.dijkstra_shortest_paths in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.maximal_cliques in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.gdistances in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.has_negative_edge_cycle in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.vertices in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.enumerate_paths in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.Graph in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.edges in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.gdistances! in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.bellman_ford_shortest_paths in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.is_directed in module IncrementalInference conflicts with an existing identifier.
WARNING: using LightGraphs.topological_sort_by_dfs in module IncrementalInference conflicts with an existing identifier.