### PR TITLE
Fix for 261

### DIFF
--- a/src/GraphsDFG/services/GraphsDFG.jl
+++ b/src/GraphsDFG/services/GraphsDFG.jl
@@ -334,7 +334,7 @@ Optionally provide a distance to specify the number of edges should be followed.
 Optionally provide an existing subgraph addToDFG, the extracted nodes will be copied into this graph. By default a new subgraph will be created.
 Note: By default orphaned factors (where the subgraph does not contain all the related variables) are not returned. Set includeOrphanFactors to return the orphans irrespective of whether the subgraph contains all the variables.
 """
-function getSubgraphAroundNode(dfg::GraphsDFG{P}, node::T, distance::Int64=1, includeOrphanFactors::Bool=false, addToDFG::G=GraphsDFG{P}(); solvable::Int=0)::GraphsDFG where {P <: AbstractParams, T <: DFGNode, G <: AbstractDFG}
+function getSubgraphAroundNode(dfg::GraphsDFG{P}, node::T, distance::Int64=1, includeOrphanFactors::Bool=false, addToDFG::G=GraphsDFG{P}(); solvable::Int=0)::AbstractDFG where {P <: AbstractParams, T <: DFGNode, G <: AbstractDFG}
     if !haskey(dfg.labelDict, node.label)
         error("Variable/factor with label '$(node.label)' does not exist in the factor graph")
     end

--- a/src/GraphsDFG/services/GraphsDFG.jl
+++ b/src/GraphsDFG/services/GraphsDFG.jl
@@ -334,7 +334,7 @@ Optionally provide a distance to specify the number of edges should be followed.
 Optionally provide an existing subgraph addToDFG, the extracted nodes will be copied into this graph. By default a new subgraph will be created.
 Note: By default orphaned factors (where the subgraph does not contain all the related variables) are not returned. Set includeOrphanFactors to return the orphans irrespective of whether the subgraph contains all the variables.
 """
-function getSubgraphAroundNode(dfg::GraphsDFG{P}, node::T, distance::Int64=1, includeOrphanFactors::Bool=false, addToDFG::GraphsDFG=GraphsDFG{P}(); solvable::Int=0)::GraphsDFG where {P <: AbstractParams, T <: DFGNode}
+function getSubgraphAroundNode(dfg::GraphsDFG{P}, node::T, distance::Int64=1, includeOrphanFactors::Bool=false, addToDFG::G=GraphsDFG{P}(); solvable::Int=0)::GraphsDFG where {P <: AbstractParams, T <: DFGNode, G <: AbstractDFG}
     if !haskey(dfg.labelDict, node.label)
         error("Variable/factor with label '$(node.label)' does not exist in the factor graph")
     end

--- a/src/LightDFG/LightDFG.jl
+++ b/src/LightDFG/LightDFG.jl
@@ -42,7 +42,8 @@ import ...DistributedFactorGraphs:  setSolverParams,
                                     getSubgraph,
                                     getAdjacencyMatrix,
                                     getAdjacencyMatrixSparse,
-                                    _getDuplicatedEmptyDFG
+                                    _getDuplicatedEmptyDFG,
+                                    _copyIntoGraph!
 
 include("FactorGraphs/FactorGraphs.jl")
 using .FactorGraphs

--- a/src/LightDFG/services/LightDFG.jl
+++ b/src/LightDFG/services/LightDFG.jl
@@ -391,7 +391,7 @@ Optionally provide a distance to specify the number of edges should be followed.
 Optionally provide an existing subgraph addToDFG, the extracted nodes will be copied into this graph. By default a new subgraph will be created.
 Note: By default orphaned factors (where the subgraph does not contain all the related variables) are not returned. Set includeOrphanFactors to return the orphans irrespective of whether the subgraph contains all the variables.
 """
-function getSubgraphAroundNode(dfg::LightDFG{P,V,F}, node::DFGNode, distance::Int64=1, includeOrphanFactors::Bool=false, addToDFG::G=LightDFG{P,V,F}(); solvable::Int=0)::LightDFG where {P <: AbstractParams, V <: AbstractDFGVariable, F <: AbstractDFGFactor, G <: AbstractDFG}
+function getSubgraphAroundNode(dfg::LightDFG{P,V,F}, node::DFGNode, distance::Int64=1, includeOrphanFactors::Bool=false, addToDFG::G=LightDFG{P,V,F}(); solvable::Int=0)::AbstractDFG where {P <: AbstractParams, V <: AbstractDFGVariable, F <: AbstractDFGFactor, G <: AbstractDFG}
     if !exists(dfg,node.label)
         error("Variable/factor with label '$(node.label)' does not exist in the factor graph")
     end

--- a/src/LightDFG/services/LightDFG.jl
+++ b/src/LightDFG/services/LightDFG.jl
@@ -410,24 +410,24 @@ end
 # dfg::LightDFG{P,V,F}
 # where {P <: AbstractParams, V <: AbstractDFGVariable, F <: AbstractDFGFactor}
 
-"""
-    $(SIGNATURES)
-Get a deep subgraph copy from the DFG given a list of variables and factors.
-Optionally provide an existing subgraph addToDFG, the extracted nodes will be copied into this graph. By default a new subgraph will be created.
-Note: By default orphaned factors (where the subgraph does not contain all the related variables) are not returned. Set includeOrphanFactors to return the orphans irrespective of whether the subgraph contains all the variables.
-"""
-function getSubgraph(dfg::LightDFG{P,V,F}, variableFactorLabels::Vector{Symbol}, includeOrphanFactors::Bool=false, addToDFG::LightDFG=LightDFG{P,V,F}())::LightDFG where {P <: AbstractParams, V <: AbstractDFGVariable, F <: AbstractDFGFactor}
-    for label in variableFactorLabels
-        if !exists(dfg, label)
-            error("Variable/factor with label '$(label)' does not exist in the factor graph")
-        end
-    end
-
-    variableFactorInts = [dfg.g.labels[s] for s in variableFactorLabels]
-
-    _copyIntoGraph!(dfg, addToDFG, variableFactorInts, includeOrphanFactors)
-    return addToDFG
-end
+# """
+#     $(SIGNATURES)
+# Get a deep subgraph copy from the DFG given a list of variables and factors.
+# Optionally provide an existing subgraph addToDFG, the extracted nodes will be copied into this graph. By default a new subgraph will be created.
+# Note: By default orphaned factors (where the subgraph does not contain all the related variables) are not returned. Set includeOrphanFactors to return the orphans irrespective of whether the subgraph contains all the variables.
+# """
+# function getSubgraph(dfg::LightDFG{P,V,F}, variableFactorLabels::Vector{Symbol}, includeOrphanFactors::Bool=false, addToDFG::LightDFG=LightDFG{P,V,F}())::LightDFG where {P <: AbstractParams, V <: AbstractDFGVariable, F <: AbstractDFGFactor}
+#     for label in variableFactorLabels
+#         if !exists(dfg, label)
+#             error("Variable/factor with label '$(label)' does not exist in the factor graph")
+#         end
+#     end
+#
+#     variableFactorInts = [dfg.g.labels[s] for s in variableFactorLabels]
+#
+#     _copyIntoGraph!(dfg, addToDFG, variableFactorInts, includeOrphanFactors)
+#     return addToDFG
+# end
 
 """
     $(SIGNATURES)

--- a/src/LightDFG/services/LightDFG.jl
+++ b/src/LightDFG/services/LightDFG.jl
@@ -391,7 +391,7 @@ Optionally provide a distance to specify the number of edges should be followed.
 Optionally provide an existing subgraph addToDFG, the extracted nodes will be copied into this graph. By default a new subgraph will be created.
 Note: By default orphaned factors (where the subgraph does not contain all the related variables) are not returned. Set includeOrphanFactors to return the orphans irrespective of whether the subgraph contains all the variables.
 """
-function getSubgraphAroundNode(dfg::LightDFG{P,V,F}, node::DFGNode, distance::Int64=1, includeOrphanFactors::Bool=false, addToDFG::LightDFG=LightDFG{P,V,F}(); solvable::Int=0)::LightDFG where {P <: AbstractParams, V <: AbstractDFGVariable, F <: AbstractDFGFactor}
+function getSubgraphAroundNode(dfg::LightDFG{P,V,F}, node::DFGNode, distance::Int64=1, includeOrphanFactors::Bool=false, addToDFG::G=LightDFG{P,V,F}(); solvable::Int=0)::LightDFG where {P <: AbstractParams, V <: AbstractDFGVariable, F <: AbstractDFGFactor, G <: AbstractDFG}
     if !exists(dfg,node.label)
         error("Variable/factor with label '$(node.label)' does not exist in the factor graph")
     end
@@ -401,7 +401,7 @@ function getSubgraphAroundNode(dfg::LightDFG{P,V,F}, node::DFGNode, distance::In
     # Always return the center node, skip that if we're filtering.
     solvable != 0 && (filter!(id -> _isSolvable(dfg, dfg.g.labels[id], solvable) || dfg.g.labels[id] == node.label, ns))
 
-    
+
     # Copy the section of graph we want
     _copyIntoGraph!(dfg, addToDFG, ns, includeOrphanFactors)
     return addToDFG

--- a/src/LightDFG/services/LightDFG.jl
+++ b/src/LightDFG/services/LightDFG.jl
@@ -347,41 +347,41 @@ function getNeighbors(dfg::LightDFG, label::Symbol; solvable::Int=0)::Vector{Sym
 
 end
 
-function _copyIntoGraph!(sourceDFG::LightDFG{<:AbstractParams, V, F}, destDFG::LightDFG{<:AbstractParams, V, F}, ns::Vector{Int}, includeOrphanFactors::Bool=false)::Nothing where {V <: AbstractDFGVariable, F <: AbstractDFGFactor}
-    #kan ek die in bulk copy, soos graph en dan nuwe map maak
-    # Add all variables first,
-    labels = [sourceDFG.g.labels[i] for i in ns]
-
-    for v in values(sourceDFG.g.variables)
-        if v.label in labels
-            exists(destDFG, v) ? (@warn "_copyIntoGraph $(v.label) exists, ignoring") : addVariable!(destDFG, deepcopy(v))
-        end
-    end
-
-    # And then all factors to the destDFG.
-    for f in values(sourceDFG.g.factors)
-        if f.label in labels
-            # Get the original factor variables (we need them to create it)
-            neigh_ints = FactorGraphs.outneighbors(sourceDFG.g, sourceDFG.g.labels[f.label])
-
-            neigh_labels = [sourceDFG.g.labels[i] for i in neigh_ints]
-            # Find the labels and associated variables in our new subgraph
-            factVariables = V[]
-            for v_lab in neigh_labels
-                if haskey(destDFG.g.variables, v_lab)
-                    push!(factVariables, getVariable(destDFG, v_lab))
-                    #otherwise ignore
-                end
-            end
-
-            # Only if we have all of them should we add it (otherwise strange things may happen on evaluation)
-            if includeOrphanFactors || length(factVariables) == length(neigh_labels)
-                exists(destDFG, f.label) ? (@warn "_copyIntoGraph $(f.label) exists, ignoring") : addFactor!(destDFG, factVariables, deepcopy(f))
-            end
-        end
-    end
-    return nothing
-end
+# function _copyIntoGraph!(sourceDFG::LightDFG{<:AbstractParams, V, F}, destDFG::LightDFG{<:AbstractParams, V, F}, ns::Vector{Int}, includeOrphanFactors::Bool=false)::Nothing where {V <: AbstractDFGVariable, F <: AbstractDFGFactor}
+#     #kan ek die in bulk copy, soos graph en dan nuwe map maak
+#     # Add all variables first,
+#     labels = [sourceDFG.g.labels[i] for i in ns]
+#
+#     for v in values(sourceDFG.g.variables)
+#         if v.label in labels
+#             exists(destDFG, v) ? (@warn "_copyIntoGraph $(v.label) exists, ignoring") : addVariable!(destDFG, deepcopy(v))
+#         end
+#     end
+#
+#     # And then all factors to the destDFG.
+#     for f in values(sourceDFG.g.factors)
+#         if f.label in labels
+#             # Get the original factor variables (we need them to create it)
+#             neigh_ints = FactorGraphs.outneighbors(sourceDFG.g, sourceDFG.g.labels[f.label])
+#
+#             neigh_labels = [sourceDFG.g.labels[i] for i in neigh_ints]
+#             # Find the labels and associated variables in our new subgraph
+#             factVariables = V[]
+#             for v_lab in neigh_labels
+#                 if haskey(destDFG.g.variables, v_lab)
+#                     push!(factVariables, getVariable(destDFG, v_lab))
+#                     #otherwise ignore
+#                 end
+#             end
+#
+#             # Only if we have all of them should we add it (otherwise strange things may happen on evaluation)
+#             if includeOrphanFactors || length(factVariables) == length(neigh_labels)
+#                 exists(destDFG, f.label) ? (@warn "_copyIntoGraph $(f.label) exists, ignoring") : addFactor!(destDFG, factVariables, deepcopy(f))
+#             end
+#         end
+#     end
+#     return nothing
+# end
 
 
 """
@@ -400,10 +400,10 @@ function getSubgraphAroundNode(dfg::LightDFG{P,V,F}, node::DFGNode, distance::In
     ns = neighborhood(dfg.g, dfg.g.labels[node.label], distance)
     # Always return the center node, skip that if we're filtering.
     solvable != 0 && (filter!(id -> _isSolvable(dfg, dfg.g.labels[id], solvable) || dfg.g.labels[id] == node.label, ns))
-
+	labels = map(id -> dfg.g.labels[id], ns)
 
     # Copy the section of graph we want
-    _copyIntoGraph!(dfg, addToDFG, ns, includeOrphanFactors)
+    _copyIntoGraph!(dfg, addToDFG, labels, includeOrphanFactors)
     return addToDFG
 
 end

--- a/src/needsahome.jl
+++ b/src/needsahome.jl
@@ -25,8 +25,7 @@ function buildSubgraphFromLabels!(dfg::GSRC,
                                   syms::Vector{Symbol};
                                   subfg::GDST=(GSRC <: InMemoryDFGTypes ? GSRC : GraphsDFG)(params=getSolverParams(dfg)),
                                   solvable::Int=0,
-                                  allowedFactors::Union{Nothing, Vector{Symbol}}=nothing  )::GDST
-                                     where {GSRC <: AbstractDFG, GDST <: AbstractDFG}
+                                  allowedFactors::Union{Nothing, Vector{Symbol}}=nothing  )::GDST where {GSRC <: AbstractDFG, GDST <: AbstractDFG}
   #
 
   # add a little too many variables (since we need the factors)
@@ -66,8 +65,7 @@ function buildSubgraphFromLabels(dfg::GSRC,
                                   syms::Vector{Symbol};
                                   subfg::GDST=(GSRC <: InMemoryDFGTypes ? GSRC : GraphsDFG)(params=getSolverParams(dfg)),
                                   solvable::Int=0,
-                                  allowedFactors::Union{Nothing, Vector{Symbol}}=nothing  )::GDST
-                                     where {GSRC <: AbstractDFG, GDST <: AbstractDFG}
+                                  allowedFactors::Union{Nothing, Vector{Symbol}}=nothing  )::GDST where {GSRC <: AbstractDFG, GDST <: AbstractDFG}
   #
   @warn "Deprecated buildSubgraphFromLabels, use buildSubgraphFromLabels! instead."
   buildSubgraphFromLabels!(dfg, syms, subfg=subfg, solvable=solvable, allowedFactors=allowedFactors )

--- a/src/needsahome.jl
+++ b/src/needsahome.jl
@@ -21,11 +21,12 @@ Related
 
 getVariableIds, _copyIntoGraph!
 """
-function buildSubgraphFromLabels!(dfg::G,
+function buildSubgraphFromLabels!(dfg::GSRC,
                                   syms::Vector{Symbol};
-                                  subfg::AbstractDFG=(G <: InMemoryDFGTypes ? G : GraphsDFG)(params=getSolverParams(dfg)),
+                                  subfg::GDST=(GSRC <: InMemoryDFGTypes ? GSRC : GraphsDFG)(params=getSolverParams(dfg)),
                                   solvable::Int=0,
-                                  allowedFactors::Union{Nothing, Vector{Symbol}}=nothing  )::G where G <: AbstractDFG
+                                  allowedFactors::Union{Nothing, Vector{Symbol}}=nothing  )::GDST
+                                     where {GSRC <: AbstractDFG, GDST <: AbstractDFG}
   #
 
   # add a little too many variables (since we need the factors)
@@ -61,11 +62,12 @@ function buildSubgraphFromLabels!(dfg::G,
   return subfg
 end
 
-function buildSubgraphFromLabels(dfg::G,
+function buildSubgraphFromLabels(dfg::GSRC,
                                   syms::Vector{Symbol};
-                                  subfg::AbstractDFG=(G <: InMemoryDFGTypes ? G : GraphsDFG)(params=getSolverParams(dfg)),
+                                  subfg::GDST=(GSRC <: InMemoryDFGTypes ? GSRC : GraphsDFG)(params=getSolverParams(dfg)),
                                   solvable::Int=0,
-                                  allowedFactors::Union{Nothing, Vector{Symbol}}=nothing  )::G where G <: AbstractDFG
+                                  allowedFactors::Union{Nothing, Vector{Symbol}}=nothing  )::GDST
+                                     where {GSRC <: AbstractDFG, GDST <: AbstractDFG}
   #
   @warn "Deprecated buildSubgraphFromLabels, use buildSubgraphFromLabels! instead."
   buildSubgraphFromLabels!(dfg, syms, subfg=subfg, solvable=solvable, allowedFactors=allowedFactors )


### PR DESCRIPTION
`getSubgraphAroundNode` should allow any type of graph to be used for the `addToDFG` parameter.

Proposed fix for https://github.com/JuliaRobotics/DistributedFactorGraphs.jl/issues/261.