### PR TITLE
Updated == and approx compares, verbose output

### DIFF
--- a/test/fileDFGTests.jl
+++ b/test/fileDFGTests.jl
@@ -45,10 +45,10 @@ using Test
         @test issetequal(ls(dfg), ls(retDFG))
         @test issetequal(lsf(dfg), lsf(retDFG))
         for var in ls(dfg)
-            @test getVariable(dfg, var) == getVariable(retDFG, var)
+            @test getVariable(dfg, var) ≈ getVariable(retDFG, var)
         end
         for fact in lsf(dfg)
-            @test getFactor(dfg, fact) == getFactor(retDFG, fact)
+            @test getFactor(dfg, fact) ≈ getFactor(retDFG, fact)
         end
 
         @test length(getBigDataEntries(getVariable(retDFG, :x1))) == 1


### PR DESCRIPTION
How about this for #308 ? I haven't tested all cases it but it allows ignores and produces verbose output.

E.g.:
```julia
v1 = addVariable!(dfg, :a, ContinuousScalar, labels = [:POSE], solvable=0)
v2 = addVariable!(dfg, :b, ContinuousScalar, labels = [:LANDMARK], solvable=1)
v1 == v2
v1a = deepcopy(v1)
v1a._dfgNodeParams._internalId = 5


v1 ≈ v2
v1a = deepcopy(v1)
v1a._dfgNodeParams._internalId = 5
v1 ≈ v1a
```

Verbose output:
```
[ Info: DFGVariable{ContinuousScalar}.label: a != b
[ Info: DFGVariable{ContinuousScalar}.tags: Set(Symbol[:VARIABLE, :POSE]) != Set(Symbol[:LANDMARK, :VARIABLE])
[ Info: DFGNodeParams.solvable: 0 != 1
[ Info: DFGVariable{ContinuousScalar}._dfgNodeParams: DFGNodeParams(0, 0) != DFGNodeParams(1, 0)
[ Info: DFGNodeParams.solvable: 0 != 1
[ Info: DFGFactor{CommonConvWrapper{LinearConditional{Normal{Float64}}},Symbol}.label: abf1 != abf2
[ Info: DFGFactor{CommonConvWrapper{LinearConditional{Normal{Float64}}},Symbol}.timestamp: 2020-02-17T23:24:07.222 != 2020-02-17T23:24:07.242
``` 