### PR TITLE
Don't allow failures on IIF tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
   allow_failures:
   - julia: nightly
   - arch: arm64
-  - env: IIF_TEST=true
+  #- env: IIF_TEST=true
 
 # Set the password for Neo4j to neo4j:test
 before_script:


### PR DESCRIPTION
Test should always be run and kept in tact otherwise there is no point of testing as the coverage drops from 85% to 50%