### PR TITLE
add broadcasting

### DIFF
--- a/src/FileDFG/services/FileDFG.jl
+++ b/src/FileDFG/services/FileDFG.jl
@@ -146,7 +146,7 @@ function loadDFG!(dfgLoadInto::AbstractDFG, dst::String)
     @info "Loaded $(length(variables)) factors - $(map(f->f.label, factors))"
     @info "Inserting factors into graph..."
     # # Adding factors
-    map(f->addFactor!(dfgLoadInto, f._variableOrderSymbols, f), factors)
+    map(f->addFactor!(dfgLoadInto, f), factors)
 
     # Finally, rebuild the CCW's for the factors to completely reinflate them
     @info "Rebuilding CCW's for the factors..."

--- a/src/services/AbstractDFG.jl
+++ b/src/services/AbstractDFG.jl
@@ -1224,6 +1224,7 @@ import Base: length, iterate
 
 # to allow stuff like `getFactorType.(dfg, [:x1x2f1;:x10l3f2])`
 # not working properly yet -- trying to immitate `add=+; add.(3,[1;2])`
+# ie shortcut for getFactorType.([dfg;dfg], [:x1x2f1;:x10l3f2]) but using Julian interfaces properly
 # https://docs.julialang.org/en/v1/manual/interfaces/#
 length(::AbstractDFG) = 1
 iterate(dfg::AbstractDFG, state::Int=0) = (dfg,state+1)

--- a/src/services/AbstractDFG.jl
+++ b/src/services/AbstractDFG.jl
@@ -1216,3 +1216,14 @@ function getSummaryGraph(dfg::G)::LightDFG{NoSolverParams, DFGVariableSummary, D
     # end
     return summaryDfg
 end
+
+
+
+## features for broadcasting
+import Base: length, iterate
+
+# to allow stuff like `getFactorType.(dfg, [:x1x2f1;:x10l3f2])`
+# not working properly yet -- trying to immitate `add=+; add.(3,[1;2])`
+# https://docs.julialang.org/en/v1/manual/interfaces/#
+length(::AbstractDFG) = 1
+iterate(dfg::AbstractDFG, state::Int=0) = (dfg,state+1)

--- a/src/services/AbstractDFG.jl
+++ b/src/services/AbstractDFG.jl
@@ -1,4 +1,14 @@
 ##==============================================================================
+## AbstractDFG
+##==============================================================================
+##------------------------------------------------------------------------------
+## Broadcasting
+##------------------------------------------------------------------------------
+# to allow stuff like `getFactorType.(dfg, [:x1x2f1;:x10l3f2])`
+# https://docs.julialang.org/en/v1/manual/interfaces/#
+Base.Broadcast.broadcastable(dfg::AbstractDFG) = Ref(dfg)
+
+##==============================================================================
 ## Interface for an AbstractDFG
 ##==============================================================================
 # Standard recommended fields to implement for AbstractDFG
@@ -1216,15 +1226,3 @@ function getSummaryGraph(dfg::G)::LightDFG{NoSolverParams, DFGVariableSummary, D
     # end
     return summaryDfg
 end
-
-
-
-## features for broadcasting
-import Base: length, iterate
-
-# to allow stuff like `getFactorType.(dfg, [:x1x2f1;:x10l3f2])`
-# not working properly yet -- trying to immitate `add=+; add.(3,[1;2])`
-# ie shortcut for getFactorType.([dfg;dfg], [:x1x2f1;:x10l3f2]) but using Julian interfaces properly
-# https://docs.julialang.org/en/v1/manual/interfaces/#
-length(::AbstractDFG) = 1
-iterate(dfg::AbstractDFG, state::Int=0) = (dfg,state+1)

--- a/test/testBlocks.jl
+++ b/test/testBlocks.jl
@@ -506,6 +506,9 @@ end
 @test ls(fg) == listVariables(fg)
 @test lsf(fg) == listFactors(fg)
 
+# simple broadcast test
+@test issetequal(getFactorType.(fg, lsf(fg)),  [TestFunctorInferenceType1(), TestFunctorSingleton()])
+@test getVariable.(fg, [:a]) == [getVariable(fg, :a)]
 end
 
 

--- a/test/testBlocks.jl
+++ b/test/testBlocks.jl
@@ -507,7 +507,9 @@ end
 @test lsf(fg) == listFactors(fg)
 
 # simple broadcast test
-@test issetequal(getFactorType.(fg, lsf(fg)),  [TestFunctorInferenceType1(), TestFunctorSingleton()])
+if f0 isa DFGFactor
+    @test issetequal(getFactorType.(fg, lsf(fg)),  [TestFunctorInferenceType1(), TestFunctorSingleton()])
+end
 @test getVariable.(fg, [:a]) == [getVariable(fg, :a)]
 end
 


### PR DESCRIPTION
I was busy here in `julia/base/abstractarray.jl`.  Something about `length(dfg) = 1` might be the problem, however, `add=+; add.(1,[2;3])` works fine while `length(::Int)==1` is always true... 

```julia
function copyto!(dest::AbstractArray, src)
    destiter = eachindex(dest)
    y = iterate(destiter)
    count = 0
    for x in src
        @show count += 1
        @show typeof(y)
        y === nothing &&
            throw(ArgumentError("destination has fewer elements than required"))
        dest[y[1]] = x
        y = iterate(destiter, y[2])
    end
    return dest
end
```