### PR TITLE
Update Deprecated.jl * Symbol

### DIFF
--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -7,6 +7,14 @@
 ## Remove in 0.9
 ##==============================================================================
 
+import Base: *
+
+# FIXME remove! is it really needed? This is type piracy
+function *(a::Symbol, b::AbstractString)::Symbol = 
+  @warn "product * on ::Symbol ::String has been deprecated, please use Symbol(\"$(a)$(b)\") directly"
+  Symbol(string(a,b))
+end
+
 setTimestamp!(f::FactorDataLevel1, ts::DateTime) = error("setTimestamp!(f::FactorDataLevel1, ts::DateTime) is deprecated")
 
 include("../attic/GraphsDFG/GraphsDFG.jl")

--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -10,8 +10,8 @@
 import Base: *
 
 # FIXME remove! is it really needed? This is type piracy
-function *(a::Symbol, b::AbstractString)::Symbol = 
-  @warn "product * on ::Symbol ::String has been deprecated, please use Symbol(\"$(a)$(b)\") directly"
+function *(a::Symbol, b::AbstractString)
+  @warn "product * on ::Symbol ::String has been deprecated, please use Symbol(string(a,b)) directly"
   Symbol(string(a,b))
 end
 


### PR DESCRIPTION
Hi @Affie ,  just a request that we please stick to proper deprecation cycles since there are downstream issues which cannot be untangled with consistent testing without doing deprecation rounds.  In this case tests in RoME are not able to jump to DFG v0.8.0 cleanly without this.