### PR TITLE
add GFND.nullhypo::Float64

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributedFactorGraphs"
 uuid = "b5cc3c7e-6572-11e9-2517-99fb8daf2f04"
-version = "0.8.1"
+version = "0.9.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/entities/DFGFactor.jl
+++ b/src/entities/DFGFactor.jl
@@ -58,12 +58,12 @@ GenericFunctionNodeData{T}() where T =
 function GenericFunctionNodeData(eliminated::Bool,
                                  potentialused::Bool,
                                  edgeIDs::Vector{Int},
-                                 fnc,
+                                 fnc::T,
                                  multihypo::Vector{<:Real}=Float64[],
                                  certainhypo::Vector{Int}=Int[],
                                  nullhypo::Real=0,
-                                 solveInP::Int=0)
-    return GenericFunctionNodeData(eliminated, potentialused, edgeIDs, fnc, multihypo, certainhypo, nullhypo, solveInP)
+                                 solveInP::Int=0) where T
+    return GenericFunctionNodeData{T}(eliminated, potentialused, edgeIDs, fnc, multihypo, certainhypo, nullhypo, solveInP)
 end
 
 

--- a/src/entities/DFGFactor.jl
+++ b/src/entities/DFGFactor.jl
@@ -61,8 +61,9 @@ function GenericFunctionNodeData(eliminated::Bool,
                                  fnc,
                                  multihypo::Vector{<:Real}=Float64[],
                                  certainhypo::Vector{Int}=Int[],
-                                 nullhypo::Real=0)
-    return GenericFunctionNodeData(eliminated, potentialused, edgeIDs, fnc, multihypo, certainhypo, nullhypo, 0)
+                                 nullhypo::Real=0,
+                                 solveInP::Int=0)
+    return GenericFunctionNodeData(eliminated, potentialused, edgeIDs, fnc, multihypo, certainhypo, nullhypo, solveInP)
 end
 
 

--- a/src/entities/DFGFactor.jl
+++ b/src/entities/DFGFactor.jl
@@ -39,23 +39,30 @@ mutable struct GenericFunctionNodeData{T<:Union{PackedInferenceType, FunctorInfe
     potentialused::Bool
     edgeIDs::Vector{Int}
     fnc::T
-    multihypo::Vector{Float64} # FIXME likely to moved when GenericWrapParam is refactored #477
+    multihypo::Vector{Float64} # TODO re-evaluate after refactoring w #477
     certainhypo::Vector{Int}
+    nullhypo::Float64
     solveInProgress::Int
+
+    # TODO deprecate all these inner constructors at end of DFG v0.9.x (was added for GFND.nullhypo::Float64 breaking change)
+    GenericFunctionNodeData{T}() where T = new{T}()
+    GenericFunctionNodeData{T}(el,po,ed,fn,mu::Vector{<:Real},ce::Vector{Int},so::Int) where T = new{T}(el,po,ed,fn,mu,ce,0.0,so)
+    GenericFunctionNodeData{T}(el,po,ed,fn,mu::Vector{<:Real},ce::Vector{Int},nu::Real,so::Int) where T = new{T}(el,po,ed,fn,mu,ce,nu,so)
 end
 
 ## Constructors
 
 GenericFunctionNodeData{T}() where T =
-    GenericFunctionNodeData{T}(false, false, Int[], T(), Float64[], Int[], 0)
+    GenericFunctionNodeData{T}(false, false, Int[], T(), Float64[], Int[], 0, 0)
 
-function GenericFunctionNodeData(eliminated,
-                                 potentialused,
-                                 edgeIDs,
+function GenericFunctionNodeData(eliminated::Bool,
+                                 potentialused::Bool,
+                                 edgeIDs::Vector{Int},
                                  fnc,
-                                 multihypo=Float64[],
-                                 certainhypo=Int[])
-    return GenericFunctionNodeData(eliminated, potentialused, edgeIDs, fnc, multihypo, certainhypo, 0)
+                                 multihypo::Vector{<:Real}=Float64[],
+                                 certainhypo::Vector{Int}=Int[],
+                                 nullhypo::Real=0)
+    return GenericFunctionNodeData(eliminated, potentialused, edgeIDs, fnc, multihypo, certainhypo, nullhypo, 0)
 end
 
 

--- a/src/services/CompareUtils.jl
+++ b/src/services/CompareUtils.jl
@@ -217,6 +217,10 @@ function compare(a::GenericFunctionNodeData{T1},b::GenericFunctionNodeData{T2}) 
   TP = TP && a.potentialused == b.potentialused
   TP = TP && a.edgeIDs == b.edgeIDs
   # TP = TP && typeof(a.fnc) == typeof(b.fnc)
+  TP = TP && (a.multihypo - b.multihypo |> norm < 1e-10)
+  TP = TP && a.certainhypo == b.certainhypo
+  TP = TP && a.nullhypo == b.nullhypo
+  TP = TP && a.solveInProgress == b.solveInProgress
   return TP
 end
 

--- a/test/testBlocks.jl
+++ b/test/testBlocks.jl
@@ -899,7 +899,7 @@ function testGroup!(fg, v1, v2, f0, f1)
         @test issetequal(ls(fg, tags=[:POSE, :LANDMARK]), ls(fg, tags=[:VARIABLE]))
 
         @test lsf(fg, tags=[:NONE]) == []
-        @test lsf(fg, tags=[:PRIOR]) == [:af1] 
+        @test lsf(fg, tags=[:PRIOR]) == [:af1]
 
         # Regexes
         @test ls(fg, r"a") == [v1.label]
@@ -1050,7 +1050,7 @@ function connectivityTestGraph(::Type{T}; VARTYPE=DFGVariable, FACTYPE=DFGFactor
         setSolvable!(dfg, :x8, 0)
         setSolvable!(dfg, :x9, 0)
 
-        gfnd = GenericFunctionNodeData(true, true, Int[], TestCCW(TestFunctorInferenceType1()), Float64[], Int[], 1)
+        gfnd = GenericFunctionNodeData(true, true, Int[], TestCCW(TestFunctorInferenceType1()), Float64[], Int[], 0, 1)
         f_tags = Set([:FACTOR])
         # f1 = DFGFactor(f1_lbl, [:a,:b], gfnd, tags = f_tags)
 


### PR DESCRIPTION
needed downstream for JuliaRobotics/IncrementalInference.jl#237

Not sure if this will effect CGDFG serialization....

@GearsAD, we can do DFG v0.10.0 for CGDFG and Data stuff if you will be busy for more than a few days in the current cycle?  No pressure at all, I'm just trying to sequence.  We will already have to punt @Affie 's IIF 459 downmsg consolidation work to IIF v0.15.0.  

IIF v0.13.0 landed yesterday and this DFG PR will result in IIF v0.14.0 to be placed directly after DFG v0.9.0 lands.  This is a breaking change to IIF.