### PR TITLE
Precompile CGDFG based on ENV variable

### DIFF
--- a/src/DistributedFactorGraphs.jl
+++ b/src/DistributedFactorGraphs.jl
@@ -289,18 +289,31 @@ include("Common.jl")
 # Data Blob extensions
 include("DataBlobs/DataBlobs.jl")
 
+if get(ENV, "DFG_USE_CGDFG", "") == "true"
+    @info "Detected ENV[\"DFG_USE_CGDFG\"]: Including optional CloudGraphsDFG (LGPL) Driver"
+    include("CloudGraphsDFG/CloudGraphsDFG.jl")
+    @reexport using .CloudGraphsDFGs
+end
+
 function __init__()
     @require GraphPlot = "a2cc645c-3eea-5389-862e-a155d0052231" begin
         @info "Including Plots"
         include("DFGPlots/DFGPlots.jl")
         @reexport using .DFGPlots
     end
-
-    if get(ENV, "DFG_USE_CGDFG", "") == "true"
-        @info "Detected ENV[\"DFG_USE_CGDFG\"]: Including optional CloudGraphsDFG (LGPL) Driver"
-        Base.include(DistributedFactorGraphs, joinpath(@__DIR__, "CloudGraphsDFG/CloudGraphsDFG.jl"))
-        @eval DistributedFactorGraphs @reexport using .CloudGraphsDFGs
-    end
+    # if get(ENV, "DFG_USE_CGDFG", "") == "true"
+    #     @require DistributedFactorGraphs = "b5cc3c7e-6572-11e9-2517-99fb8daf2f04" begin
+    #         @info "Detected ENV[\"DFG_USE_CGDFG\"]: Including optional CloudGraphsDFG (LGPL) Driver"
+    #         include("CloudGraphsDFG/CloudGraphsDFG.jl")
+    #         @reexport using .CloudGraphsDFGs
+    #     end
+    # end
+    # && !Requires.isprecompiling()
+    # if get(ENV, "DFG_USE_CGDFG", "") == "true"
+    #     @info "Detected ENV[\"DFG_USE_CGDFG\"]: Including optional CloudGraphsDFG (LGPL) Driver"
+    #     Base.include(DistributedFactorGraphs, joinpath(@__DIR__, "CloudGraphsDFG/CloudGraphsDFG.jl"))
+    #     @eval DistributedFactorGraphs @reexport using .CloudGraphsDFGs
+    # end
 end
 
 

--- a/src/DistributedFactorGraphs.jl
+++ b/src/DistributedFactorGraphs.jl
@@ -301,19 +301,6 @@ function __init__()
         include("DFGPlots/DFGPlots.jl")
         @reexport using .DFGPlots
     end
-    # if get(ENV, "DFG_USE_CGDFG", "") == "true"
-    #     @require DistributedFactorGraphs = "b5cc3c7e-6572-11e9-2517-99fb8daf2f04" begin
-    #         @info "Detected ENV[\"DFG_USE_CGDFG\"]: Including optional CloudGraphsDFG (LGPL) Driver"
-    #         include("CloudGraphsDFG/CloudGraphsDFG.jl")
-    #         @reexport using .CloudGraphsDFGs
-    #     end
-    # end
-    # && !Requires.isprecompiling()
-    # if get(ENV, "DFG_USE_CGDFG", "") == "true"
-    #     @info "Detected ENV[\"DFG_USE_CGDFG\"]: Including optional CloudGraphsDFG (LGPL) Driver"
-    #     Base.include(DistributedFactorGraphs, joinpath(@__DIR__, "CloudGraphsDFG/CloudGraphsDFG.jl"))
-    #     @eval DistributedFactorGraphs @reexport using .CloudGraphsDFGs
-    # end
 end
 
 


### PR DESCRIPTION
Temporary fix for #554
This is not really a good idea. It looks like new updates to Pkg might provide a better solution.
Note that ENV variable DFG_USE_CGDFG should be seen as a permanent feature setting as CGDF will be precompiled into the cache. 