### PR TITLE
Robust ZonedTimestamp fixer

### DIFF
--- a/src/services/Serialization.jl
+++ b/src/services/Serialization.jl
@@ -21,9 +21,12 @@ function _fixSubseconds(a)
 end
 
 function getStandardZDTString(stringTimestamp::String)
+    # Additional check+fix for the ultraweird "2020-08-12T12:00Z"
+    ts = replace(stringTimestamp, r"T(\d\d):(\d\d)(Z|z|\+|-)" => s"T\1:\2:00.000\3")
+
     # This is finding :59Z or :59.82-05:00 and fixing it to always have 3 subsecond digits.
     # Temporary fix until TimeZones.jl gets an upstream fix.
-    return replace(stringTimestamp, r":\d\d(\.\d+)?(Z|z|\+|-)" => _fixSubseconds)
+    return replace(ts, r":\d\d(\.\d+)?(Z|z|\+|-)" => _fixSubseconds)
 end
 
 # Corrects any `::ZonedDateTime` fields of T in corresponding `interm::Dict` as `dateformat"yyyy-mm-ddTHH:MM:SS.ssszzz"`


### PR DESCRIPTION
Robust regex+function for cleaning up ZonedTimestamps from Neo4J and other places where it experiences formatting alchemy.

For a test, try this:
```julia
using TimeZones
s = [
"2020-08-12T12:00Z",  #Johan's test case
"2020-08-11T04:05:59-04:00",
"2020-08-11T04:05:59Z",
"2020-08-11T04:05:59.8-04:00",
"2020-08-11T04:05:59.82-04:00",
"2020-08-11T04:05:59.820-04:00",
"2020-08-11T04:05:59.8201-04:00"]

function _fixSubseconds(a)
    length(a) == 4 && return a[1:3]*".000"*a[4]
    frac = a[5:length(a)-1]
    frac = length(frac) > 3 ? frac[1:3] : frac*'0'^(3-length(frac))
    return a[1:4]*frac*a[length(a)]
end

function getStandardZDTString(stringTimestamp::String)
    # Additional check+fix for the ultraweird "2020-08-12T12:00Z"
    ts = replace(stringTimestamp, r"T(\d\d):(\d\d)(Z|z|\+|-)" => s"T\1:\2:00.000\3")

    # This is finding :59Z or :59.82-05:00 and fixing it to always have 3 subsecond digits.
    # Temporary fix until TimeZones.jl gets an upstream fix.
    return replace(ts, r":\d\d(\.\d+)?(Z|z|\+|-)" => _fixSubseconds)
end

for m in s
    print(getStandardZDTString(m)*"\r\n")
end
```

