### PR TITLE
better include sequence

### DIFF
--- a/src/DistributedFactorGraphs.jl
+++ b/src/DistributedFactorGraphs.jl
@@ -277,11 +277,14 @@ const DefaultDFG = LightDFG
 
 # Common includes
 include("services/CommonAccessors.jl")
-include("services/Serialization.jl")
 include("services/DFGVariable.jl")
 include("services/DFGFactor.jl")
 include("Deprecated.jl")
 include("services/CompareUtils.jl")
+include("Common.jl")
+include("DataBlobs/DataBlobs.jl")
+
+include("services/Serialization.jl")
 
 # Include the FilesDFG API.
 include("FileDFG/FileDFG.jl")
@@ -289,11 +292,7 @@ include("FileDFG/FileDFG.jl")
 # Custom show and printing for variable factor etc.
 include("services/CustomPrinting.jl")
 
-# To be moved as necessary.
-include("Common.jl")
 
-# Data Blob extensions
-include("DataBlobs/DataBlobs.jl")
 
 if get(ENV, "DFG_USE_CGDFG", "") == "true"
     @info "Detected ENV[\"DFG_USE_CGDFG\"]: Including optional CloudGraphsDFG (LGPL) Driver"


### PR DESCRIPTION
Even with this PR, still getting the following issue:
```julia
julia> loadDFG!(fg, "tenSolves.tar.gz")
sfolder = split(dstname, '.') = SubString{String}["tenSolves", "tar", "gz"]
[ Info: loadDFG detected a gzip tenSolves.tar.gz -- unpacking via /tmp/caesar/random/d618894c-dc95-11ea-36c5-ab0f381c205b now...
ERROR: UndefVarError: DistributedFactorGraphs.BlobStoreEntry not defined
Stacktrace:
 [1] unpackVariable(::LightDFG{SolverParams,DFGVariable,DFGFactor}, ::Dict{String,Any}; unpackPPEs::Bool, unpackSolverData::Bool, unpackBigData::Bool) at /home/dehann/.julia/dev/DistributedFactorGraphs/src/services/Serialization.jl:125
 [2] unpackVariable at /home/dehann/.julia/dev/DistributedFactorGraphs/src/services/Serialization.jl:74 [inlined]
 [3] (::DistributedFactorGraphs.var"#153#159"{LightDFG{SolverParams,DFGVariable,DFGFactor},Array{DFGVariable,1}})(::IOStream) at /home/dehann/.julia/dev/DistributedFactorGraphs/src/FileDFG/services/FileDFG.jl:134
 [4] open(::DistributedFactorGraphs.var"#153#159"{LightDFG{SolverParams,DFGVariable,DFGFactor},Array{DFGVariable,1}}, ::String; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./io.jl:325
 [5] open at ./io.jl:323 [inlined]
 [6] loadDFG!(::LightDFG{SolverParams,DFGVariable,DFGFactor}, ::String) at /home/dehann/.julia/dev/DistributedFactorGraphs/src/FileDFG/services/FileDFG.jl:132
 [7] top-level scope at REPL[3]:1
```