### PR TITLE
Types are serialized into every CGDFG node, which is unnecessary and causing issues

### DIFF
--- a/src/CloudGraphsDFG/services/CloudGraphsDFG.jl
+++ b/src/CloudGraphsDFG/services/CloudGraphsDFG.jl
@@ -535,9 +535,9 @@ function _unpackPPE(dfg::G, packedPPE::Dict{String, Any})::AbstractPointParametr
         packedPPE["lastUpdatedTimestamp"] = packedPPE["lastUpdatedTimestamp"][1:end-1]
     end
 
-    !haskey(packedPPE, "_type") && error("Cannot find type key '$TYPEKEY' in packed PPE data")
+    !haskey(packedPPE, "_type") && error("Cannot find type key '_type' in packed PPE data")
     type = pop!(packedPPE, "_type")
-    (type == nothing || type == "") && error("Cannot deserialize PPE, type key is empty")
+    (type === nothing || type == "") && error("Cannot deserialize PPE, type key is empty")
     ppe = Unmarshal.unmarshal(
             DistributedFactorGraphs.getTypeFromSerializationModule(dfg, Symbol(type)),
             packedPPE)
@@ -555,6 +555,9 @@ end
 
 function _generateAdditionalProperties(softType::ST, ppe::P)::Dict{String, String} where {P <: AbstractPointParametricEst, ST <: InferenceVariable}
     addProps = Dict{String, String}()
+    # Save in the type for PPEs
+    addProps["_type"]="\"$(typeof(ppe))\""
+
     # Try get the projectCartesian function for this softType
     projectCartesianFunc = nothing
     if isdefined(Main, :projectCartesian)
@@ -572,6 +575,7 @@ function _generateAdditionalProperties(softType::ST, ppe::P)::Dict{String, Strin
         cart = Main.projectCartesian(softType, est) # Assuming we've imported the variables into Main
         addProps["$(field)_cart3"] = "point({x:$(cart[1]),y:$(cart[2]),z:$(cart[3])})" # Need to look at 3D too soon.
     end
+
     return addProps
 end
 

--- a/src/CloudGraphsDFG/services/CommonFunctions.jl
+++ b/src/CloudGraphsDFG/services/CommonFunctions.jl
@@ -203,9 +203,8 @@ function _structToNeo4jProps(inst::Union{User, Robot, Session, PVND, N, APPE, AB
     for (k, v) in addProps
         write(io, "$cypherNodeName.$k= $v,")
     end
-    # Write in the version and node type
-    write(io, "$cypherNodeName._version=\"$(_getDFGVersion())\",")
-    write(io, "$cypherNodeName._type=\"$(typeof(inst))\"")
+    # Write in the version
+    write(io, "$cypherNodeName._version=\"$(_getDFGVersion())\"")
     # Ref String(): "When possible, the memory of v will be used without copying when the String object is created.
     # This is guaranteed to be the case for byte vectors returned by take!" # Apparent replacement for takebuf_string()
     return String(take!(io))


### PR DESCRIPTION
This resolves it by only serializing `_type` in for PPEs.

Setting this up for testing, need to figure out where everything is before merging.