### PR TITLE
add AbstractFactor and AbstractPackedFactor

### DIFF
--- a/src/DistributedFactorGraphs.jl
+++ b/src/DistributedFactorGraphs.jl
@@ -193,7 +193,8 @@ export addData!
 ##------------------------------------------------------------------------------
 # Factor Data
 export GenericFunctionNodeData, PackedFunctionNodeData, FunctionNodeData
-export FunctorInferenceType, PackedInferenceType
+export AbstractFactor, AbstractPackedFactor
+export FunctorInferenceType, PackedInferenceType # NOTE might be deprecated in the future (const aliases)
 export AbstractPrior, AbstractRelative, AbstractRelativeRoots, AbstractRelativeMinimize
 export FactorOperationalMemory
 

--- a/src/entities/DFGFactor.jl
+++ b/src/entities/DFGFactor.jl
@@ -3,16 +3,19 @@
 ##==============================================================================
 
 # TODO consider changing this to AbstractFactor
-abstract type FunctorInferenceType <: Function end
-abstract type PackedInferenceType end
+abstract type AbstractFactor end
+const FunctorInferenceType = AbstractFactor
+abstract type AbstractPackedFactor end
+const PackedInferenceType = AbstractPackedFactor
 
-abstract type AbstractPrior <: FunctorInferenceType end
-abstract type AbstractRelative <: FunctorInferenceType end
+abstract type AbstractPrior <: AbstractFactor end
+abstract type AbstractRelative <: AbstractFactor end
 abstract type AbstractRelativeRoots <: AbstractRelative end
 abstract type AbstractRelativeMinimize <: AbstractRelative end
 
 # NOTE DF, Convolution is IIF idea, but DFG should know about "FactorOperationalMemory"
 # DF, IIF.CommonConvWrapper <: FactorOperationalMemory #
+# TODO resolve whether `<: Function` is really needed here
 abstract type FactorOperationalMemory <: Function end
 # TODO to be removed from DFG,
 # we can add to IIF or have IIF.CommonConvWrapper <: FactorOperationalMemory directly


### PR DESCRIPTION
also dropped the `<: Function` inheritance.