### PR TITLE
top level JSON2.write only, distr are JSON

### DIFF
--- a/src/Neo4jDFG/services/Neo4jDFG.jl
+++ b/src/Neo4jDFG/services/Neo4jDFG.jl
@@ -271,7 +271,9 @@ function getFactor(dfg::Neo4jDFG, label::Union{Symbol, String})
     props = result.results[1]["data"][1]["row"][1]
 
     # NOTE: Until we address #590, base64 decode the data to ensure robustness, #833
-    props["data"] = String(base64decode(props["data"]))
+    # TODO: consolidate with top level only JSON, #848
+    packedData = String(base64decode(props["data"]))
+    props["data"] = JSON2.read(packedData)
 
     return rebuildFactorMetadata!(dfg, unpackFactor(dfg, props))
 end

--- a/src/entities/DFGFactor.jl
+++ b/src/entities/DFGFactor.jl
@@ -46,12 +46,6 @@ mutable struct GenericFunctionNodeData{T<:Union{<:AbstractPackedFactor, <:Abstra
     nullhypo::Float64
     solveInProgress::Int
     inflation::Float64
-    # inner constructor needed for dual use
-    # GenericFunctionNodeData{T}(x1::Bool,x2::Bool,x3,x4::T,args...) where T = new{T}(x1,x2,x3,x4,args...)
-    # TODO deprecate all these inner constructors at end of DFG v0.9.x (was added for GFND.nullhypo::Float64 breaking change)
-    # GenericFunctionNodeData{T}(el,po,ed,fn,mu::Vector{<:Real},ce::Vector{Int},so::Int) where T = 
-    #                            new{T}(el,po,ed,fn,mu,ce,0.0,so)
-    # GenericFunctionNodeData{T}(el,po,ed,fn,mu::Vector{<:Real},ce::Vector{Int},nu::Real,so::Int,infl::Real) where T = new{T}(el,po,ed,fn,mu,ce,nu,so,infl)
 end
 
 ## Constructors

--- a/test/testBlocks.jl
+++ b/test/testBlocks.jl
@@ -56,7 +56,7 @@ end
 
 
 Base.@kwdef struct PackedTestAbstractPrior <: AbstractPackedFactor
-    s::String
+    s::String = ""
 end
 # PackedTestAbstractPrior() = PackedTestAbstractPrior("")
 

--- a/test/testBlocks.jl
+++ b/test/testBlocks.jl
@@ -34,10 +34,10 @@ struct TestAbstractPrior <: AbstractPrior end
 struct TestAbstractRelativeFactor <: AbstractRelativeRoots end
 struct TestAbstractRelativeFactorMinimize <: AbstractRelativeMinimize end
 
-struct PackedTestFunctorInferenceType1 <: AbstractPackedFactor
-    s::String
+Base.@kwdef struct PackedTestFunctorInferenceType1 <: AbstractPackedFactor
+    s::String = ""
 end
-PackedTestFunctorInferenceType1() = PackedTestFunctorInferenceType1("")
+# PackedTestFunctorInferenceType1() = PackedTestFunctorInferenceType1("")
 
 function Base.convert(::Type{PackedTestFunctorInferenceType1}, d::TestFunctorInferenceType1)
     # @info "convert(::Type{PackedTestFunctorInferenceType1}, d::TestFunctorInferenceType1)"
@@ -55,10 +55,10 @@ function Base.convert(::Type{TestFunctorInferenceType1}, d::PackedTestFunctorInf
 end
 
 
-struct PackedTestAbstractPrior <: AbstractPackedFactor
+Base.@kwdef struct PackedTestAbstractPrior <: AbstractPackedFactor
     s::String
 end
-PackedTestAbstractPrior() = PackedTestAbstractPrior("")
+# PackedTestAbstractPrior() = PackedTestAbstractPrior("")
 
 function Base.convert(::Type{PackedTestAbstractPrior}, d::TestAbstractPrior)
     # @info "convert(::Type{PackedTestAbstractPrior}, d::TestAbstractPrior)"


### PR DESCRIPTION
Neo4jDFG `pack / unpackFactor` not consolidated with `AbstractDFG` (#834).  Factor `solverData` still packed for Neo4jDFG driver as
```julia
props["data"] = base64encode(JSON2.write(convert(PackedFunctionNodeData{P}, getSolverData(fct)))
```

Everyone else should now have factor packed data as top level only `JSON.write` (i.e. just once at the top).

This PR requires that `PackedFactor__` structs are defined with keyword constructors, as used by new `NamedTuple` style marshaling during unpack of JSON2 objects.  In other words, JSON2 is used to unpack factor data without a target type, and therefore returns a `Base.NamedTuple` (great solution for unordered JSON fields).  This allows/now requires DFG to use keyword constructors for all `<:AbstractPackedFactor`.  Easiest way to do so is `Base.@kwdef struct ___`,  For example:
https://github.com/JuliaRobotics/DistributedFactorGraphs.jl/blob/79a54937c17821f0152fb9316dde3c5cc720d8fe/test/testBlocks.jl#L37-L39

Note, default parameters DO NOT have to be provided!  All we care about is that a keyword constructor exists.  User can build the keyword constructor themselves if `@kwdef` is not a workable solution.

The new unordered marshal magic happens here:
https://github.com/JuliaRobotics/DistributedFactorGraphs.jl/blob/79a54937c17821f0152fb9316dde3c5cc720d8fe/src/services/Serialization.jl#L351-L354

xref #590 