### PR TITLE
Bump v0.18.4, ManifoldsBase and DocStringExtensions compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributedFactorGraphs"
 uuid = "b5cc3c7e-6572-11e9-2517-99fb8daf2f04"
-version = "0.18.3"
+version = "0.18.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -28,13 +28,13 @@ Unmarshal = "cbff2730-442d-58d7-89d1-8e530c41eb02"
 [compat]
 Colors = "0.10, 0.11, 0.12"
 Distributions = "0.23, 0.24, 0.25"
-DocStringExtensions = "0.8"
+DocStringExtensions = "0.8, 0.9"
 Graphs = "1.4"
 GraphPlot = "0.5.0"
 JSON = "0.21"
 JSON2 = "0.3.1"
 LightGraphs = "1.2, 1.3"
-ManifoldsBase = "0.11, 0.12"
+ManifoldsBase = "0.11, 0.12, 0.13"
 Neo4j = "2"
 Pkg = "1.4, 1.5"
 Reexport = "1"


### PR DESCRIPTION
ManifoldsBase upgrade is not a breaking change in DFG, so only adding to compat

replace and close #871 
replace and close #880