### PR TITLE
Hotfix for PPE serialization - these are missing in the cloud v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributedFactorGraphs"
 uuid = "b5cc3c7e-6572-11e9-2517-99fb8daf2f04"
-version = "0.18.10"
+version = "0.18.11"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/services/Serialization.jl
+++ b/src/services/Serialization.jl
@@ -221,7 +221,7 @@ function unpackVariable(
     end
 
     # FIXME, drop nested packing, see DFG #867
-    ppeDict = if unpackPPEs && haskey(packedProps,"ppesDict")
+    ppeDict = if unpackPPEs && haskey(packedProps,"ppeDict")
         JSON2.read(packedProps["ppeDict"], Dict{Symbol, MeanMaxPPE})
     elseif unpackPPEs && haskey(packedProps,"ppes") && packedProps["ppes"] isa AbstractVector
         # these different cases are not well covered in tests, but first fix #867


### PR DESCRIPTION
PPEs are missing because of a spelling mistake. Adding this as a hotfix.

Reference:
```
"label" => "x0", "dataEntry" => "{}", "nstime" => "0", "dataEntryType" => "{}", "ppeDict" => "{\"default\":{\"solveKey\":\"test\",\"suggested\":[1.0,2.0,3.0],\"max\":[4.0,5.0,6.0],\"mean\":[7.0,8.0,9.0],\"lastUpdatedTimestamp\":\"2023-02-17T23:10:17.982\"}}", "solverDataDict" => "{\"parametric\":...
```