### PR TITLE
implement mergeStates!

### DIFF
--- a/src/services/DFGVariable.jl
+++ b/src/services/DFGVariable.jl
@@ -740,6 +740,17 @@ function mergeStates!(dfg::AbstractDFG, varLabel_state_pairs::Vector{Pair{Symbol
     return sum(cnt)
 end
 
+function mergeStates!(
+    dfg::AbstractDFG,
+    variableLabel::Symbol,
+    states::Vector{<:State},
+)
+    cnt = asyncmap(states) do state
+        return mergeState!(dfg, variableLabel, state)
+    end
+    return sum(cnt)
+end
+
 function copytoState!(
     dfg::AbstractDFG,
     variableLabel::Symbol,

--- a/src/services/DFGVariable.jl
+++ b/src/services/DFGVariable.jl
@@ -733,7 +733,7 @@ function mergeState!(v::VariableCompute, vnd::State)
     return 1
 end
 
-function mergeStates!(dfg::AbstractDFG, varLabel_state_pairs::Vector{Pair{Symbol, VariableState}})
+function mergeStates!(dfg::AbstractDFG, varLabel_state_pairs::Vector{Pair{Symbol, State}})
     cnt = asyncmap(varLabel_state_pairs) do (varLabel, state)
         return mergeState!(dfg, varLabel, state)
     end

--- a/src/services/DFGVariable.jl
+++ b/src/services/DFGVariable.jl
@@ -733,6 +733,13 @@ function mergeState!(v::VariableCompute, vnd::State)
     return 1
 end
 
+function mergeStates!(dfg::AbstractDFG, varLabel_state_pairs::Vector{Pair{Symbol, VariableState}})
+    cnt = asyncmap(varLabel_state_pairs) do (varLabel, state)
+        return mergeState!(dfg, varLabel, state)
+    end
+    return sum(cnt)
+end
+
 function copytoState!(
     dfg::AbstractDFG,
     variableLabel::Symbol,

--- a/src/services/DFGVariable.jl
+++ b/src/services/DFGVariable.jl
@@ -740,11 +740,7 @@ function mergeStates!(dfg::AbstractDFG, varLabel_state_pairs::Vector{Pair{Symbol
     return sum(cnt)
 end
 
-function mergeStates!(
-    dfg::AbstractDFG,
-    variableLabel::Symbol,
-    states::Vector{<:State},
-)
+function mergeStates!(dfg::AbstractDFG, variableLabel::Symbol, states::Vector{<:State})
     cnt = asyncmap(states) do state
         return mergeState!(dfg, variableLabel, state)
     end

--- a/test/testBlocks.jl
+++ b/test/testBlocks.jl
@@ -787,7 +787,7 @@ function VSDTestBlock!(fg, v1)
     # Bulk copy update x0
     @test DFG.copytoState!(fg, v1.label, :default, getState(fg, v1.label, :default)) == 1
 
-    @test DFG.mergeStates!(fg, Vector{Pair{Symbol, VariableState}}([:a=>vnd])) == 1
+    @test DFG.mergeStates!(fg, Vector{Pair{Symbol, State}}([:a=>vnd])) == 1
     
     altVnd = vnd |> deepcopy
     keepVnd = getState(getVariable(fg, :a), :parametric) |> deepcopy

--- a/test/testBlocks.jl
+++ b/test/testBlocks.jl
@@ -789,6 +789,9 @@ function VSDTestBlock!(fg, v1)
 
     @test DFG.mergeStates!(fg, Vector{Pair{Symbol, State}}([:a=>vnd])) == 1
     
+    @test DFG.mergeStates!(fg, [:a=>vnd]) == 1
+    @test DFG.mergeStates!(fg, :a, [vnd]) == 1
+    
     altVnd = vnd |> deepcopy
     keepVnd = getState(getVariable(fg, :a), :parametric) |> deepcopy
 

--- a/test/testBlocks.jl
+++ b/test/testBlocks.jl
@@ -787,6 +787,8 @@ function VSDTestBlock!(fg, v1)
     # Bulk copy update x0
     @test DFG.copytoState!(fg, v1.label, :default, getState(fg, v1.label, :default)) == 1
 
+    @test DFG.mergeStates!(fg, Vector{Pair{Symbol, VariableState}}([:a=>vnd])) == 1
+    
     altVnd = vnd |> deepcopy
     keepVnd = getState(getVariable(fg, :a), :parametric) |> deepcopy
 

--- a/test/testBlocks.jl
+++ b/test/testBlocks.jl
@@ -788,10 +788,8 @@ function VSDTestBlock!(fg, v1)
     @test DFG.copytoState!(fg, v1.label, :default, getState(fg, v1.label, :default)) == 1
 
     @test DFG.mergeStates!(fg, Vector{Pair{Symbol, State}}([:a=>vnd])) == 1
-    
     @test DFG.mergeStates!(fg, [:a=>vnd]) == 1
     @test DFG.mergeStates!(fg, :a, [vnd]) == 1
-    
     altVnd = vnd |> deepcopy
     keepVnd = getState(getVariable(fg, :a), :parametric) |> deepcopy
 


### PR DESCRIPTION
I went back and forth on `mergeVariableStates!` and comparing it with `updateVariableNodeData!` and settled on following the verb by still providing a container. The same concept can be followed for all satellite levels (such as `Blobentry`)

@dehann would you mind giving your inputs.

